### PR TITLE
adjust message handing

### DIFF
--- a/internal/chatlog/mcp/const.go
+++ b/internal/chatlog/mcp/const.go
@@ -26,6 +26,7 @@ var (
 					"description": "联系人的搜索关键词，可以是姓名、备注名或ID。",
 				},
 			},
+			Required: []string{"query"},
 		},
 	}
 
@@ -40,6 +41,7 @@ var (
 					"description": "群聊的搜索关键词，可以是群名称、群ID或相关描述",
 				},
 			},
+			Required: []string{"query"},
 		},
 	}
 
@@ -67,6 +69,7 @@ var (
 					"description": "交谈对象，可以是联系人或群聊。支持使用ID、昵称、备注名等进行查询。",
 				},
 			},
+			Required: []string{"time", "talker"},
 		},
 	}
 

--- a/internal/chatlog/mcp/service.go
+++ b/internal/chatlog/mcp/service.go
@@ -191,9 +191,6 @@ func (s *Service) toolsCall(session *mcp.Session, req *mcp.Request) error {
 			talker = v.(string)
 		}
 		limit := util.MustAnyToInt(callReq.Arguments["limit"])
-		if limit == 0 {
-			limit = 100
-		}
 		offset := util.MustAnyToInt(callReq.Arguments["offset"])
 		messages, err := s.db.GetMessages(start, end, talker, limit, offset)
 		if err != nil {
@@ -264,9 +261,6 @@ func (s *Service) resourcesRead(session *mcp.Session, req *mcp.Request) error {
 			return fmt.Errorf("无法解析时间范围")
 		}
 		limit := util.MustAnyToInt(u.Query().Get("limit"))
-		if limit == 0 {
-			limit = 100
-		}
 		offset := util.MustAnyToInt(u.Query().Get("offset"))
 		messages, err := s.db.GetMessages(start, end, u.Host, limit, offset)
 		if err != nil {

--- a/internal/mcp/tool.go
+++ b/internal/mcp/tool.go
@@ -92,8 +92,9 @@ type Tool struct {
 }
 
 type ToolSchema struct {
-	Type       string `json:"type"`
-	Properties M      `json:"properties"`
+	Type       string   `json:"type"`
+	Properties M        `json:"properties"`
+	Required   []string `json:"required,omitempty"`
 }
 
 //	{

--- a/internal/model/message_darwinv3.go
+++ b/internal/model/message_darwinv3.go
@@ -27,48 +27,31 @@ type MessageDarwinV3 struct {
 	MsgContent    string `json:"msgContent"`
 	MessageType   int64  `json:"messageType"`
 	MesDes        int    `json:"mesDes"` // 0: 发送, 1: 接收
-
-	// MesLocalID      int64  `json:"mesLocalID"`
-	// MesSvrID        int64  `json:"mesSvrID"`
-	// MesStatus       int    `json:"mesStatus"`
-	// MesImgStatus    int    `json:"mesImgStatus"`
-	// MsgSource       string `json:"msgSource"`
-	// IntRes1         int    `json:"IntRes1"`
-	// IntRes2         int    `json:"IntRes2"`
-	// StrRes1         string `json:"StrRes1"`
-	// StrRes2         string `json:"StrRes2"`
-	// MesVoiceText    string `json:"mesVoiceText"`
-	// MesSeq          int    `json:"mesSeq"`
-	// CompressContent []byte `json:"CompressContent"`
-	// ConBlob         []byte `json:"ConBlob"`
 }
 
 func (m *MessageDarwinV3) Wrap(talker string) *Message {
 
 	_m := &Message{
-		CreateTime: time.Unix(m.MsgCreateTime, 0),
+		Time:       time.Unix(m.MsgCreateTime, 0),
 		Type:       m.MessageType,
-		IsSender:   (m.MesDes + 1) % 2,
+		Talker:     talker,
+		IsChatRoom: strings.HasSuffix(talker, "@chatroom"),
+		IsSelf:     m.MesDes == 0,
 		Version:    WeChatDarwinV3,
 	}
 
-	_m.IsChatRoom = strings.HasSuffix(talker, "@chatroom")
-
-	_m.Content = m.MsgContent
+	content := m.MsgContent
 	if _m.IsChatRoom {
-		split := strings.SplitN(m.MsgContent, ":\n", 2)
+		split := strings.SplitN(content, ":\n", 2)
 		if len(split) == 2 {
-			_m.ChatRoomSender = split[0]
-			_m.Content = split[1]
+			_m.Sender = split[0]
+			content = split[1]
 		}
+	} else if !_m.IsSelf {
+		_m.Sender = talker
 	}
 
-	if _m.Type != 1 {
-		mediaMessage, err := NewMediaMessage(_m.Type, _m.Content)
-		if err == nil {
-			_m.MediaMessage = mediaMessage
-		}
-	}
+	_m.ParseMediaInfo(content)
 
 	return _m
 }

--- a/internal/model/message_v3.go
+++ b/internal/model/message_v3.go
@@ -1,0 +1,117 @@
+package model
+
+import (
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sjzar/chatlog/internal/model/wxproto"
+	"github.com/sjzar/chatlog/pkg/util/lz4"
+	"google.golang.org/protobuf/proto"
+)
+
+// CREATE TABLE MSG (
+// localId INTEGER PRIMARY KEY AUTOINCREMENT,
+// TalkerId INT DEFAULT 0,
+// MsgSvrID INT,
+// Type INT,
+// SubType INT,
+// IsSender INT,
+// CreateTime INT,
+// Sequence INT DEFAULT 0,
+// StatusEx INT DEFAULT 0,
+// FlagEx INT,
+// Status INT,
+// MsgServerSeq INT,
+// MsgSequence INT,
+// StrTalker TEXT,
+// StrContent TEXT,
+// DisplayContent TEXT,
+// Reserved0 INT DEFAULT 0,
+// Reserved1 INT DEFAULT 0,
+// Reserved2 INT DEFAULT 0,
+// Reserved3 INT DEFAULT 0,
+// Reserved4 TEXT,
+// Reserved5 TEXT,
+// Reserved6 TEXT,
+// CompressContent BLOB,
+// BytesExtra BLOB,
+// BytesTrans BLOB
+// )
+type MessageV3 struct {
+	Sequence        int64  `json:"Sequence"`        // 消息序号，10位时间戳 + 3位序号
+	CreateTime      int64  `json:"CreateTime"`      // 消息创建时间，10位时间戳
+	StrTalker       string `json:"StrTalker"`       // 聊天对象，微信 ID or 群 ID
+	IsSender        int    `json:"IsSender"`        // 是否为发送消息，0 接收消息，1 发送消息
+	Type            int64  `json:"Type"`            // 消息类型
+	SubType         int    `json:"SubType"`         // 消息子类型
+	StrContent      string `json:"StrContent"`      // 消息内容，文字聊天内容 或 XML
+	CompressContent []byte `json:"CompressContent"` // 非文字聊天内容，如图片、语音、视频等
+	BytesExtra      []byte `json:"BytesExtra"`      // protobuf 额外数据，记录群聊发送人等信息
+}
+
+func (m *MessageV3) Wrap() *Message {
+
+	_m := &Message{
+		Seq:        m.Sequence,
+		Time:       time.Unix(m.CreateTime, 0),
+		Talker:     m.StrTalker,
+		IsChatRoom: strings.HasSuffix(m.StrTalker, "@chatroom"),
+		IsSelf:     m.IsSender == 1,
+		Type:       m.Type,
+		SubType:    int64(m.SubType),
+		Content:    m.StrContent,
+		Version:    WeChatV3,
+	}
+
+	if !_m.IsChatRoom && !_m.IsSelf {
+		_m.Sender = m.StrTalker
+	}
+
+	if _m.Type == 49 {
+		b, err := lz4.Decompress(m.CompressContent)
+		if err == nil {
+			_m.Content = string(b)
+		}
+	}
+
+	_m.ParseMediaInfo(_m.Content)
+
+	if len(m.BytesExtra) != 0 {
+		if bytesExtra := ParseBytesExtra(m.BytesExtra); bytesExtra != nil {
+			if _m.IsChatRoom {
+				_m.Sender = bytesExtra[1]
+			}
+			// FIXME xml 中的 md5 数据无法匹配到 hardlink 记录，所以直接用 proto 数据
+			if _m.Type == 43 {
+				path := bytesExtra[4]
+				parts := strings.Split(filepath.ToSlash(path), "/")
+				if len(parts) > 1 {
+					path = strings.Join(parts[1:], "/")
+				}
+				_m.Contents["path"] = path
+			}
+		}
+	}
+
+	return _m
+}
+
+// ParseBytesExtra 解析额外数据
+// 按需解析
+func ParseBytesExtra(b []byte) map[int]string {
+	var pbMsg wxproto.BytesExtra
+	if err := proto.Unmarshal(b, &pbMsg); err != nil {
+		return nil
+	}
+	if pbMsg.Items == nil {
+		return nil
+	}
+
+	ret := make(map[int]string, len(pbMsg.Items))
+	for _, item := range pbMsg.Items {
+		ret[int(item.Type)] = item.Value
+	}
+
+	return ret
+}

--- a/internal/wechatdb/datasource/windowsv3/datasource.go
+++ b/internal/wechatdb/datasource/windowsv3/datasource.go
@@ -293,7 +293,7 @@ func (ds *DataSource) GetMessages(ctx context.Context, startTime, endTime time.T
 		}
 
 		query := fmt.Sprintf(`
-            SELECT Sequence, CreateTime, TalkerId, StrTalker, IsSender, 
+            SELECT Sequence, CreateTime, StrTalker, IsSender, 
                 Type, SubType, StrContent, CompressContent, BytesExtra
             FROM MSG 
             WHERE %s 
@@ -316,7 +316,6 @@ func (ds *DataSource) GetMessages(ctx context.Context, startTime, endTime time.T
 			err := rows.Scan(
 				&msg.Sequence,
 				&msg.CreateTime,
-				&msg.TalkerID,
 				&msg.StrTalker,
 				&msg.IsSender,
 				&msg.Type,
@@ -343,7 +342,7 @@ func (ds *DataSource) GetMessages(ctx context.Context, startTime, endTime time.T
 
 	// 对所有消息按时间排序
 	sort.Slice(totalMessages, func(i, j int) bool {
-		return totalMessages[i].Sequence < totalMessages[j].Sequence
+		return totalMessages[i].Seq < totalMessages[j].Seq
 	})
 
 	// 处理分页
@@ -378,7 +377,7 @@ func (ds *DataSource) getMessagesSingleFile(ctx context.Context, dbInfo MessageD
 		}
 	}
 	query := fmt.Sprintf(`
-        SELECT Sequence, CreateTime, TalkerId, StrTalker, IsSender, 
+        SELECT Sequence, CreateTime, StrTalker, IsSender, 
             Type, SubType, StrContent, CompressContent, BytesExtra
         FROM MSG 
         WHERE %s 
@@ -409,7 +408,6 @@ func (ds *DataSource) getMessagesSingleFile(ctx context.Context, dbInfo MessageD
 		err := rows.Scan(
 			&msg.Sequence,
 			&msg.CreateTime,
-			&msg.TalkerID,
 			&msg.StrTalker,
 			&msg.IsSender,
 			&msg.Type,

--- a/internal/wechatdb/repository/message.go
+++ b/internal/wechatdb/repository/message.go
@@ -41,28 +41,24 @@ func (r *Repository) EnrichMessages(ctx context.Context, messages []*model.Messa
 
 // enrichMessage 补充单条消息的额外信息
 func (r *Repository) enrichMessage(msg *model.Message) {
-	talker := msg.Talker
-
 	// 处理群聊消息
 	if msg.IsChatRoom {
-		talker = msg.ChatRoomSender
-
 		// 补充群聊名称
 		if chatRoom, ok := r.chatRoomCache[msg.Talker]; ok {
-			msg.ChatRoomName = chatRoom.DisplayName()
+			msg.TalkerName = chatRoom.DisplayName()
 
 			// 补充发送者在群里的显示名称
-			if displayName, ok := chatRoom.User2DisplayName[talker]; ok {
-				msg.DisplayName = displayName
+			if displayName, ok := chatRoom.User2DisplayName[msg.Sender]; ok {
+				msg.SenderName = displayName
 			}
 		}
 	}
 
 	// 如果不是自己发送的消息且还没有显示名称，尝试补充发送者信息
-	if msg.DisplayName == "" && msg.IsSender != 1 {
-		contact := r.getFullContact(talker)
+	if msg.SenderName == "" && !msg.IsSelf {
+		contact := r.getFullContact(msg.Sender)
 		if contact != nil {
-			msg.DisplayName = contact.DisplayName()
+			msg.SenderName = contact.DisplayName()
 		}
 	}
 }


### PR DESCRIPTION
- 调整消息处理逻辑
  - 移除 `MediaMessage` 结构体，相关业务逻辑由 `Message` 处理
  - 支持小程序、视频号、拍一拍、转账、系统消息等消息类型
- 优化 json 格式聊天记录输出，不再会有 json 中嵌套 xml 的情况出现
- 移除 MCP API 中 聊天记录条目限制 https://github.com/sjzar/chatlog/issues/17
- 为 MCP 查询参数增加 `required` 标识 https://github.com/sjzar/chatlog/issues/21