### PR TITLE
support multi key pattern matching

### DIFF
--- a/cmd/chatlog/log.go
+++ b/cmd/chatlog/log.go
@@ -22,6 +22,8 @@ func initLog(cmd *cobra.Command, args []string) {
 	if Debug {
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	}
+
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339})
 }
 
 func initTuiLog(cmd *cobra.Command, args []string) {

--- a/internal/wechat/decrypt/validator.go
+++ b/internal/wechat/decrypt/validator.go
@@ -15,13 +15,17 @@ type Validator struct {
 }
 
 // NewValidator 创建一个仅用于验证的验证器
-func NewValidator(dataDir string, platform string, version int) (*Validator, error) {
+func NewValidator(platform string, version int, dataDir string) (*Validator, error) {
+	dbFile := GetSimpleDBFile(platform, version)
+	dbPath := filepath.Join(dataDir + "/" + dbFile)
+	return NewValidatorWithFile(platform, version, dbPath)
+}
+
+func NewValidatorWithFile(platform string, version int, dbPath string) (*Validator, error) {
 	decryptor, err := NewDecryptor(platform, version)
 	if err != nil {
 		return nil, err
 	}
-	dbFile := GetSimpleDBFile(platform, version)
-	dbPath := filepath.Join(dataDir + "/" + dbFile)
 	d, err := common.OpenDBFile(dbPath, decryptor.GetPageSize())
 	if err != nil {
 		return nil, err

--- a/internal/wechat/key/extractor.go
+++ b/internal/wechat/key/extractor.go
@@ -15,6 +15,9 @@ type Extractor interface {
 	// Extract 从进程中提取密钥
 	Extract(ctx context.Context, proc *model.Process) (string, error)
 
+	// SearchKey 在内存中搜索密钥
+	SearchKey(ctx context.Context, memory []byte) (string, bool)
+
 	SetValidate(validator *decrypt.Validator)
 }
 

--- a/internal/wechat/key/windows/v3.go
+++ b/internal/wechat/key/windows/v3.go
@@ -1,6 +1,8 @@
 package windows
 
 import (
+	"context"
+
 	"github.com/sjzar/chatlog/internal/wechat/decrypt"
 )
 
@@ -10,6 +12,11 @@ type V3Extractor struct {
 
 func NewV3Extractor() *V3Extractor {
 	return &V3Extractor{}
+}
+
+func (e *V3Extractor) SearchKey(ctx context.Context, memory []byte) (string, bool) {
+	// TODO : Implement the key search logic for V3
+	return "", false
 }
 
 func (e *V3Extractor) SetValidate(validator *decrypt.Validator) {

--- a/internal/wechat/key/windows/v4.go
+++ b/internal/wechat/key/windows/v4.go
@@ -1,6 +1,8 @@
 package windows
 
 import (
+	"context"
+
 	"github.com/sjzar/chatlog/internal/wechat/decrypt"
 )
 
@@ -10,6 +12,11 @@ type V4Extractor struct {
 
 func NewV4Extractor() *V4Extractor {
 	return &V4Extractor{}
+}
+
+func (e *V4Extractor) SearchKey(ctx context.Context, memory []byte) (string, bool) {
+	// TODO : Implement the key search logic for V4
+	return "", false
 }
 
 func (e *V4Extractor) SetValidate(validator *decrypt.Validator) {

--- a/internal/wechat/wechat.go
+++ b/internal/wechat/wechat.go
@@ -90,7 +90,7 @@ func (a *Account) GetKey(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	validator, err := decrypt.NewValidator(process.DataDir, process.Platform, process.Version)
+	validator, err := decrypt.NewValidator(process.Platform, process.Version, process.DataDir)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
- 支持内存多特征匹配
- 调整命令行工具下的 Log 格式

---
检查了用户提供的 dump 数据，部分 intel macOS 的用户无法获取有效密钥的原因，应该和 Nano Zone 内存区域分配大小有关，暂不清楚具体的内存分配策略，所以先支持了多特征匹配的能力，增加获取密钥的可能性。