### PR TITLE
server command

### DIFF
--- a/internal/chatlog/http/service.go
+++ b/internal/chatlog/http/service.go
@@ -77,6 +77,21 @@ func (s *Service) Start() error {
 	return nil
 }
 
+func (s *Service) ListenAndServe() error {
+
+	if s.ctx.HTTPAddr == "" {
+		s.ctx.HTTPAddr = DefalutHTTPAddr
+	}
+
+	s.server = &http.Server{
+		Addr:    s.ctx.HTTPAddr,
+		Handler: s.router,
+	}
+
+	log.Info().Msg("Starting HTTP server on " + s.ctx.HTTPAddr)
+	return s.server.ListenAndServe()
+}
+
 func (s *Service) Stop() error {
 
 	if s.server == nil {

--- a/internal/wechat/process/windows/detector.go
+++ b/internal/wechat/process/windows/detector.go
@@ -13,8 +13,8 @@ import (
 const (
 	V3ProcessName = "WeChat"
 	V4ProcessName = "Weixin"
-	V3DBFile      = "Msg\\Misc.db"
-	V4DBFile      = "db_storage\\message\\message_0.db"
+	V3DBFile      = `Msg\Misc.db`
+	V4DBFile      = `db_storage\session\session.db`
 )
 
 // Detector 实现 Windows 平台的进程检测器


### PR DESCRIPTION
- 支持 `server` 命令，可独立启动 HTTP 服务
- 优化 windows 版本在线状态判断逻辑

---
```shell
# server 命令
chatlog server \
  --addr "127.0.0.1:5030" \
  --data-dir "/Users/sarv/Library/Containers/com.tencent.xinWeChat/Data/Documents/xwechat_files/user" \
  --work-dir "/Users/sarv/Documents/chatlog/user" \
  --platform "darwin" \
  --version 4
```