### PR TITLE
fix(wechatdb): hardlink v4 & init db

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -118,3 +118,7 @@ func Err(c *gin.Context, err error) {
 
 	c.JSON(http.StatusInternalServerError, err.Error())
 }
+
+func Is(err, target error) bool {
+	return errors.Is(err, target)
+}

--- a/internal/model/message.go
+++ b/internal/model/message.go
@@ -245,14 +245,9 @@ func (m *Message) PlainTextContent() string {
 				keylist = append(keylist, md5)
 			}
 		}
-		if m.Contents["imgfile"] != nil {
-			if imgfile, ok := m.Contents["imgfile"].(string); ok {
-				keylist = append(keylist, imgfile)
-			}
-		}
-		if m.Contents["thumb"] != nil {
-			if thumb, ok := m.Contents["thumb"].(string); ok {
-				keylist = append(keylist, thumb)
+		if m.Contents["path"] != nil {
+			if path, ok := m.Contents["path"].(string); ok {
+				keylist = append(keylist, path)
 			}
 		}
 		return fmt.Sprintf("![图片](http://%s/image/%s)", m.Contents["host"], strings.Join(keylist, ","))
@@ -275,14 +270,9 @@ func (m *Message) PlainTextContent() string {
 				keylist = append(keylist, rawmd5)
 			}
 		}
-		if m.Contents["videofile"] != nil {
-			if videofile, ok := m.Contents["videofile"].(string); ok {
-				keylist = append(keylist, videofile)
-			}
-		}
-		if m.Contents["thumb"] != nil {
-			if thumb, ok := m.Contents["thumb"].(string); ok {
-				keylist = append(keylist, thumb)
+		if m.Contents["path"] != nil {
+			if path, ok := m.Contents["path"].(string); ok {
+				keylist = append(keylist, path)
 			}
 		}
 		return fmt.Sprintf("![视频](http://%s/video/%s)", m.Contents["host"], strings.Join(keylist, ","))

--- a/internal/model/message_v4.go
+++ b/internal/model/message_v4.go
@@ -90,12 +90,10 @@ func (m *MessageV4) Wrap(talker string) *Message {
 			if _m.Type == 3 && packedInfo.Image != nil {
 				_talkerMd5Bytes := md5.Sum([]byte(talker))
 				talkerMd5 := hex.EncodeToString(_talkerMd5Bytes[:])
-				_m.Contents["imgfile"] = filepath.Join("msg", "attach", talkerMd5, _m.Time.Format("2006-01"), "Img", fmt.Sprintf("%s.dat", packedInfo.Image.Md5))
-				_m.Contents["thumb"] = filepath.Join("msg", "attach", talkerMd5, _m.Time.Format("2006-01"), "Img", fmt.Sprintf("%s_t.dat", packedInfo.Image.Md5))
+				_m.Contents["path"] = filepath.Join("msg", "attach", talkerMd5, _m.Time.Format("2006-01"), "Img", packedInfo.Image.Md5)
 			}
 			if _m.Type == 43 && packedInfo.Video != nil {
-				_m.Contents["videofile"] = filepath.Join("msg", "video", _m.Time.Format("2006-01"), fmt.Sprintf("%s.mp4", packedInfo.Video.Md5))
-				_m.Contents["thumb"] = filepath.Join("msg", "video", _m.Time.Format("2006-01"), fmt.Sprintf("%s_thumb.jpg", packedInfo.Video.Md5))
+				_m.Contents["path"] = filepath.Join("msg", "video", _m.Time.Format("2006-01"), packedInfo.Video.Md5)
 			}
 		}
 	}

--- a/internal/wechatdb/datasource/v4/datasource.go
+++ b/internal/wechatdb/datasource/v4/datasource.go
@@ -162,6 +162,10 @@ func (ds *DataSource) initMessageDbs() error {
 			infos[i].EndTime = infos[i+1].StartTime
 		}
 	}
+	if len(ds.messageInfos) > 0 && len(infos) < len(ds.messageInfos) {
+		log.Warn().Msgf("message db count decreased from %d to %d, skip init", len(ds.messageInfos), len(infos))
+		return nil
+	}
 	ds.messageInfos = infos
 	return nil
 }
@@ -603,10 +607,20 @@ func (ds *DataSource) GetMedia(ctx context.Context, _type string, key string) (*
 	switch _type {
 	case "image":
 		table = "image_hardlink_info_v3"
+		// 4.1.0 版本开始使用 v4 表
+		if !ds.IsExist(Media, table) {
+			table = "image_hardlink_info_v4"
+		}
 	case "video":
 		table = "video_hardlink_info_v3"
+		if !ds.IsExist(Media, table) {
+			table = "video_hardlink_info_v4"
+		}
 	case "file":
 		table = "file_hardlink_info_v3"
+		if !ds.IsExist(Media, table) {
+			table = "file_hardlink_info_v4"
+		}
 	case "voice":
 		return ds.GetVoice(ctx, key)
 	default:
@@ -659,8 +673,8 @@ func (ds *DataSource) GetMedia(ctx context.Context, _type string, key string) (*
 		mediaV4.Type = _type
 		media = mediaV4.Wrap()
 
-		// 跳过缩略图
-		if _type == "image" && !strings.Contains(media.Name, "_t") {
+		// 优先返回高清图
+		if _type == "image" && strings.HasSuffix(mediaV4.Name, "_h.dat") {
 			break
 		}
 	}
@@ -670,6 +684,22 @@ func (ds *DataSource) GetMedia(ctx context.Context, _type string, key string) (*
 	}
 
 	return media, nil
+}
+
+func (ds *DataSource) IsExist(_db string, table string) bool {
+	db, err := ds.dbm.GetDB(_db)
+	if err != nil {
+		return false
+	}
+	var tableName string
+	query := "SELECT name FROM sqlite_master WHERE type='table' AND name=?;"
+	if err = db.QueryRow(query, table).Scan(&tableName); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false
+		}
+		return false
+	}
+	return true
 }
 
 func (ds *DataSource) GetVoice(ctx context.Context, key string) (*model.Media, error) {

--- a/internal/wechatdb/datasource/windowsv3/datasource.go
+++ b/internal/wechatdb/datasource/windowsv3/datasource.go
@@ -56,7 +56,7 @@ var Groups = []*dbm.Group{
 	},
 	{
 		Name:      Voice,
-		Pattern:   `^MediaMSG([0-9])?\.db$`,
+		Pattern:   `^MediaMSG([0-9]?[0-9])?\.db$`,
 		BlackList: []string{},
 	},
 }
@@ -206,6 +206,10 @@ func (ds *DataSource) initMessageDbs() error {
 		} else {
 			infos[i].EndTime = infos[i+1].StartTime
 		}
+	}
+	if len(ds.messageInfos) > 0 && len(infos) < len(ds.messageInfos) {
+		log.Warn().Msgf("message db count decreased from %d to %d, skip init", len(ds.messageInfos), len(infos))
+		return nil
 	}
 	ds.messageInfos = infos
 	return nil

--- a/internal/wechatdb/repository/chatroom.go
+++ b/internal/wechatdb/repository/chatroom.go
@@ -5,17 +5,14 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/sjzar/chatlog/internal/errors"
 	"github.com/sjzar/chatlog/internal/model"
 )
 
 // initChatRoomCache 初始化群聊缓存
 func (r *Repository) initChatRoomCache(ctx context.Context) error {
-	// 加载所有群聊到缓存
-	chatRooms, err := r.ds.GetChatRooms(ctx, "", 0, 0)
-	if err != nil {
-		return err
-	}
 
 	chatRoomMap := make(map[string]*model.ChatRoom)
 	remarkToChatRoom := make(map[string][]*model.ChatRoom)
@@ -23,6 +20,13 @@ func (r *Repository) initChatRoomCache(ctx context.Context) error {
 	chatRoomList := make([]string, 0)
 	chatRoomRemark := make([]string, 0)
 	chatRoomNickName := make([]string, 0)
+
+	// 加载所有群聊到缓存
+	// 暂时忽略获取不到群聊的错误
+	chatRooms, err := r.ds.GetChatRooms(ctx, "", 0, 0)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to load chat rooms")
+	}
 
 	for _, chatRoom := range chatRooms {
 		// 补充群聊信息（从联系人中获取 Remark 和 NickName）

--- a/internal/wechatdb/repository/contact.go
+++ b/internal/wechatdb/repository/contact.go
@@ -5,17 +5,14 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/sjzar/chatlog/internal/errors"
 	"github.com/sjzar/chatlog/internal/model"
 )
 
 // initContactCache 初始化联系人缓存
 func (r *Repository) initContactCache(ctx context.Context) error {
-	// 加载所有联系人到缓存
-	contacts, err := r.ds.GetContacts(ctx, "", 0, 0)
-	if err != nil {
-		return err
-	}
 
 	contactMap := make(map[string]*model.Contact)
 	aliasMap := make(map[string][]*model.Contact)
@@ -27,6 +24,13 @@ func (r *Repository) initContactCache(ctx context.Context) error {
 	aliasList := make([]string, 0)
 	remarkList := make([]string, 0)
 	nickNameList := make([]string, 0)
+
+	// 加载所有联系人到缓存
+	// 暂时忽略获取不到联系人的错误
+	contacts, err := r.ds.GetContacts(ctx, "", 0, 0)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to load contacts")
+	}
 
 	for _, contact := range contacts {
 		contactMap[contact.UserName] = contact


### PR DESCRIPTION
修点 BUG

**1. 增强多版本兼容性**
- 新增对微信 4.1.0 版本 `_v4` 媒体表的回退支持。当 `_v3` 表不存在时，系统会自动尝试从新版 `file_hardlink_info_v4` 等表中读取数据。
- 简化了图片和视频消息的 URL。在提供服务时，通过动态探测（`.dat`, `_h.dat`, `.mp4` 等）来定位并返回正确的媒体文件。
- 优化了 Windows V3版本语音数据库的正则表达式，使其能匹配超过 10 个 `MediaMSG.db` 文件

**2. 增强容错能力**
- 在初始化联系人与群聊缓存时，将原有的致命错误降级为日志记录，允许程序在无法完全加载通讯录时也能成功启动。
- 增加了对消息数据库数量的检测，当检测到数据库文件数量减少时，会跳过本次初始化，以防止因微信运行时文件锁定等临时问题导致后续查询失败。

**3. 功能与体验优化**
- 优化了图片媒体文件的选择逻辑，现在会优先返回高清原图（以 `_h.dat` 结尾的文件）。