### PR TITLE
Fix data_key assignment in cmd_decrypt.go

### DIFF
--- a/cmd/chatlog/cmd_decrypt.go
+++ b/cmd/chatlog/cmd_decrypt.go
@@ -48,7 +48,7 @@ func getDecryptConfig() map[string]any {
 		cmdConf["data_dir"] = decryptDataDir
 	}
 	if len(decryptDatakey) != 0 {
-		cmdConf["data_key"] = serverDataKey
+		cmdConf["data_key"] = decryptDatakey
 	}
 	if len(decryptWorkDir) != 0 {
 		cmdConf["work_dir"] = decryptWorkDir


### PR DESCRIPTION
cmd_decrypt.go的key的赋值命令是错的, 修正一下