### PR TITLE
fix(conf): tui config write failed

### DIFF
--- a/internal/chatlog/conf/conf.go
+++ b/internal/chatlog/conf/conf.go
@@ -37,6 +37,10 @@ func LoadTUIConfig(configPath string) (*TUIConfig, *config.Manager, error) {
 		return nil, nil, err
 	}
 	conf.ConfigDir = tcm.Path
+
+	b, _ := json.Marshal(conf)
+	log.Info().Msgf("tui config: %s", string(b))
+
 	return conf, tcm, nil
 }
 
@@ -84,6 +88,9 @@ func LoadServiceConfig(configPath string, cmdConf map[string]any) (*ServerConfig
 			return nil, nil, err
 		}
 	}
+
+	b, _ := json.Marshal(conf)
+	log.Info().Msgf("server config: %s", string(b))
 
 	return conf, scm, nil
 }

--- a/internal/chatlog/conf/tui.go
+++ b/internal/chatlog/conf/tui.go
@@ -1,7 +1,7 @@
 package conf
 
 type TUIConfig struct {
-	ConfigDir   string          `mapstructure:"-"`
+	ConfigDir   string          `mapstructure:"-" json:"config_dir"`
 	LastAccount string          `mapstructure:"last_account" json:"last_account"`
 	History     []ProcessConfig `mapstructure:"history" json:"history"`
 	Webhook     *Webhook        `mapstructure:"webhook" json:"webhook"`

--- a/internal/chatlog/database/service.go
+++ b/internal/chatlog/database/service.go
@@ -116,6 +116,7 @@ func (s *Service) initWebhook() error {
 	s.webhookCancel = cancel
 	hooks := s.webhook.GetHooks(ctx, s.db)
 	for _, hook := range hooks {
+		log.Info().Msgf("set callback %#v", hook)
 		if err := s.db.SetCallback(hook.Group(), hook.Callback); err != nil {
 			log.Error().Err(err).Msgf("set callback %#v failed", hook)
 			return err

--- a/internal/chatlog/webhook/webhook.go
+++ b/internal/chatlog/webhook/webhook.go
@@ -186,7 +186,7 @@ func (m *MessageWebhook) Do(event fsnotify.Event) {
 	req, _ := http.NewRequest("POST", m.conf.URL, bytes.NewBuffer(body))
 	req.Header.Set("Content-Type", "application/json")
 
-	log.Debug().Msgf("post messages to %s, body: %s", m.conf.URL, string(body))
+	log.Info().Msgf("post messages to %s, body: %s", m.conf.URL, string(body))
 	resp, err := m.client.Do(req)
 	if err != nil {
 		log.Error().Err(err).Msgf("post messages failed")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -83,11 +83,12 @@ func New(app, path, name, envPrefix string, writeConfig bool) (*Manager, error) 
 	}
 
 	return &Manager{
-		App:       app,
-		EnvPrefix: envPrefix,
-		Path:      path,
-		Name:      name,
-		Viper:     v,
+		App:         app,
+		EnvPrefix:   envPrefix,
+		Path:        path,
+		Name:        name,
+		Viper:       v,
+		WriteConfig: writeConfig,
 	}, nil
 }
 
@@ -95,6 +96,7 @@ func New(app, path, name, envPrefix string, writeConfig bool) (*Manager, error) 
 // It unmarshals the configuration into the provided conf interface.
 func (c *Manager) Load(conf interface{}) error {
 	if err := c.Viper.ReadInConfig(); err != nil {
+		log.Error().Err(err).Msg("read config failed")
 		if c.WriteConfig {
 			if err := c.Viper.SafeWriteConfig(); err != nil {
 				return err


### PR DESCRIPTION
修个 BUG，当本地配置文件为空时，TUI 模式无法写入新的配置文件。

**1. TUI 配置问题**
- 修复 TUI 配置写入失败的问题，原因是 `WriteConfig` 参数未正确赋值。

**2. 补充日志信息**
- 在读取配置文件失败时，增加明确的错误日志。
- 在 TUI 和服务配置加载阶段，增加日志以打印完整的 JSON 格式配置内容，方便快速定位配置问题。
- 将 Webhook 发送消息的日志级别从 Debug 提升为 Info，确保在生产环境中也能追踪到消息推送。